### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,4 +142,4 @@ mvn compile exec:java -Dexec.mainClass="com.tobe.DensePredictClient" -Dexec.args
 
 This project is widely used for different tasks with dense or sparse data.
 
-If you want to make contirbutions, feel free to open an [issue](https://github.com/tobegit3hub/deep_recommend_system/issues) or [pull-request](https://github.com/tobegit3hub/deep_recommend_system/pulls).
+If you want to make contributions, feel free to open an [issue](https://github.com/tobegit3hub/deep_recommend_system/issues) or [pull-request](https://github.com/tobegit3hub/deep_recommend_system/pulls).

--- a/cpp_predict_client/README.md
+++ b/cpp_predict_client/README.md
@@ -8,7 +8,7 @@ Now you need to use `bazel` and just refer to to [inception_client.cc](https://g
 
 ## Usage
 
-Add the build rule in `tensorflow_serving/example/BUILD` and copy [sparse_predict_client.cc](./sparse_predict_client.cc) in example direcotry.
+Add the build rule in `tensorflow_serving/example/BUILD` and copy [sparse_predict_client.cc](./sparse_predict_client.cc) in example directory.
 
 ```
 cc_binary(


### PR DESCRIPTION
There are small typos in:
- README.md
- cpp_predict_client/README.md

Fixes:
- Should read `directory` rather than `direcotry`.
- Should read `contributions` rather than `contirbutions`.